### PR TITLE
Fixed links for docker and server structure

### DIFF
--- a/ServerAdministration/ServerOverview.md
+++ b/ServerAdministration/ServerOverview.md
@@ -23,9 +23,9 @@ Codename:	bionic
 |---                    |---                                        |                                
 | API Proxies           | [Github](https://github.com/aau-giraf)    | 
 
-An illustration of the current server architecture can be seen in [Server Structure](.ServerArchitecture.md)
+An illustration of the current server architecture can be seen in [Server Structure](ServerArchitecture.md)
 
-The structure of how docker works can also be read about in [Docker Structure](.docker.md)
+The structure of how docker works can also be read about in [Docker Structure](docker.md)
 
 ITS is responsible for the NFS that is mounted on all the nodes and masters in `/swarm-nfs/`.
 


### PR DESCRIPTION
removed the . that was in front of ServerArchitecture.md and docker.md