### PR TITLE
Fixes 132

### DIFF
--- a/docs/development/security/file_licenses.md
+++ b/docs/development/security/file_licenses.md
@@ -4,8 +4,11 @@
 All licenses for pictograms should be here... 
 
 ## Sound Licenses
-License for the DingSound.mp3 used for the timer in the Weekplanner-application: [Soundsnap License](https://www.soundsnap.com/licence)
+DingSound.mp3 file used for the timer in the Weekplanner-application: <br>
+- Download from [Soundsnap](https://www.soundsnap.com/8bit_status_point_39_wav) <br>
+- License available at [Soundsnap License](https://www.soundsnap.com/licence) <br>
 
 ## Other Licenses
-License for the Quicksand-font used in the Weekplanner-application: 
-[SIL Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL)
+Quicksand-font used in the Weekplanner-application: <br>
+- Download from [Google Fonts](https://fonts.google.com/specimen/Quicksand) <br>
+- License available at [SIL Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL) <br>

--- a/docs/development/security/file_licenses.md
+++ b/docs/development/security/file_licenses.md
@@ -1,0 +1,11 @@
+# File Licenses
+
+## Pictogram Licenses
+All licenses for pictograms should be here... 
+
+## Sound Licenses
+License for the DingSound.mp3 used for the timer in the Weekplanner-application: [Soundsnap License](https://www.soundsnap.com/licence)
+
+## Other Licenses
+License for the Quicksand-font used in the Weekplanner-application: 
+[SIL Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL)

--- a/docs/development/security/licences.md
+++ b/docs/development/security/licences.md
@@ -13,8 +13,8 @@ DingSound.mp3 file used for the timer in the Weekplanner-application: <br>
 
 ## Icon Licenses 
 FallBackImage icon used in the Weekplanner-application (available in the Wiki-repository under GIRAF-icons): <br>
-- Download from [Font Awesome](https://fontawesome.com/icons/image?style=regular) <br>
-- License available at [Font Awesome Free License](https://fontawesome.com/license/free) <br>
+- Download from [Font Awesome](https://fontawesome.com/icons/image?style=regular) (accessed at 20/04/2020) <br>
+- License available at [Font Awesome Free License](https://fontawesome.com/license/free) (accessed at 20/04/2020) <br>
 
 Folder icon (folder.svg) and AddFolder icon (addFolder.svg): <br>
 - Developed by a development group in 2020S1 <br>
@@ -22,8 +22,8 @@ Folder icon (folder.svg) and AddFolder icon (addFolder.svg): <br>
 
 According to the report "Product Owner of Giraf" written by group SW610F19 in the GIRAF 2019 project all icons are from Font Awesome with exception of the icons changeToCitizen and changeToGuardian which are developed by themselves. <br>
 - See p. 36 l. 1 in the report <br>
-- Download from [Font Awesome](https://fontawesome.com) by searching the icons file-name with the exceptions of gallery.png (search for "images"), cancel.png ("close") and addUser ("user") <br>
-- License available at [Font Awesome Free License](https://fontawesome.com/license/free) <br>
+- Download from [Font Awesome](https://fontawesome.com) by searching the icons file-name with the exceptions of gallery.png (search for "images"), cancel.png ("close") and addUser ("user") (accessed at 20/04/2020) <br>
+- License available at [Font Awesome Free License](https://fontawesome.com/license/free) (accessed at 17/04/2020) <br>
 
 ## Other Licenses
 Quicksand-font used in the Weekplanner-application: <br>

--- a/docs/development/security/licences.md
+++ b/docs/development/security/licences.md
@@ -1,7 +1,10 @@
 # Licenses
+In this section of the Wiki you will find the licenses used to build the applications in the GIRAF platform. 
 
 ## Pictogram Licenses
-All licenses for pictograms should be here... 
+All pictograms used within the Weekplanner application are from the ARAASAC symbol collection. This collection has been translated to Danish by the communication centre at Hilleroed Kommune. <br>
+- Download from [Picto Selector](https://www.kc-hil.dk/viden-og-udvikling-mega/paedagogisk-materiale/picto-selector) <br>
+- License available at [Creative Common's License](https://creativecommons.org/licenses/?lang=da) <br>
 
 ## Sound Licenses
 DingSound.mp3 file used for the timer in the Weekplanner-application: <br>

--- a/docs/development/security/licences.md
+++ b/docs/development/security/licences.md
@@ -12,9 +12,18 @@ DingSound.mp3 file used for the timer in the Weekplanner-application: <br>
 - License available at [Soundsnap License](https://www.soundsnap.com/licence) (accessed at 17/04/2020) <br>
 
 ## Icon Licenses 
-xx file used in the Weekplanner-application: <br>
-- Download from xx <br>
-- License available at xx <br>
+FallBackImage icon used in the Weekplanner-application (available in the Wiki-repository under GIRAF-icons): <br>
+- Download from [Font Awesome](https://fontawesome.com/icons/image?style=regular) <br>
+- License available at [Font Awesome Free License](https://fontawesome.com/license/free) <br>
+
+Folder icon (folder.svg) and AddFolder icon (addFolder.svg): <br>
+- Developed by a development group in 2020S1 <br>
+- No license needed <br>
+
+According to the report "Product Owner of Giraf" written by group SW610F19 in the GIRAF 2019 project all icons are from Font Awesome with exception of the icons changeToCitizen and changeToGuardian which are developed by themselves. <br>
+- See p. 36 l. 1 in the report <br>
+- Download from [Font Awesome](https://fontawesome.com) by searching the icons file-name with the exceptions of gallery.png (search for "images"), cancel.png ("close") and addUser ("user") <br>
+- License available at [Font Awesome Free License](https://fontawesome.com/license/free) <br>
 
 ## Other Licenses
 Quicksand-font used in the Weekplanner-application: <br>

--- a/docs/development/security/licences.md
+++ b/docs/development/security/licences.md
@@ -1,4 +1,4 @@
-# File Licenses
+# Licenses
 
 ## Pictogram Licenses
 All licenses for pictograms should be here... 

--- a/docs/development/security/licences.md
+++ b/docs/development/security/licences.md
@@ -3,15 +3,20 @@ In this section of the Wiki you will find the licenses used to build the applica
 
 ## Pictogram Licenses
 All pictograms used within the Weekplanner application are from the ARAASAC symbol collection. This collection has been translated to Danish by the communication centre at Hilleroed Kommune. <br>
-- Download from [Picto Selector](https://www.kc-hil.dk/viden-og-udvikling-mega/paedagogisk-materiale/picto-selector) <br>
-- License available at [Creative Common's License](https://creativecommons.org/licenses/?lang=da) <br>
+- Download from [Picto Selector](https://www.kc-hil.dk/viden-og-udvikling-mega/paedagogisk-materiale/picto-selector) (accessed at 17/04/2020) <br>
+- License available at [Creative Common's License](https://creativecommons.org/licenses/?lang=da) (accessed at 17/04/2020) <br>
 
 ## Sound Licenses
 DingSound.mp3 file used for the timer in the Weekplanner-application: <br>
-- Download from [Soundsnap](https://www.soundsnap.com/8bit_status_point_39_wav) <br>
-- License available at [Soundsnap License](https://www.soundsnap.com/licence) <br>
+- Download from [Soundsnap](https://www.soundsnap.com/8bit_status_point_39_wav) (accessed at 17/04/2020) <br>
+- License available at [Soundsnap License](https://www.soundsnap.com/licence) (accessed at 17/04/2020) <br>
+
+## Icon Licenses 
+xx file used in the Weekplanner-application: <br>
+- Download from xx <br>
+- License available at xx <br>
 
 ## Other Licenses
 Quicksand-font used in the Weekplanner-application: <br>
-- Download from [Google Fonts](https://fonts.google.com/specimen/Quicksand) <br>
-- License available at [SIL Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL) <br>
+- Download from [Google Fonts](https://fonts.google.com/specimen/Quicksand) (accessed at 17/04/2020) <br>
+- License available at [SIL Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL) (accessed at 17/04/2020) <br>


### PR DESCRIPTION
Fixes #132 : Added licenses for all files used in the GIRAF platform

All licenses for all files used in the GIRAF platform is now available in the wiki-repository under security/licenses.md. This file should be updated during development whenever a new icon or sound, etc., is used. 