### PR TITLE
Changed file names for releases in 2020

### DIFF
--- a/docs/releases/2020fs1r1.md
+++ b/docs/releases/2020fs1r1.md
@@ -1,6 +1,6 @@
 **Release**
 
-These are the user stories that were included in 2020s1r1:
+These are the user stories that were included in 2020fs1r1:
 
 | **Issue ID**   |**Developed by**                                                            |
 | -------------- |---------------------------------------------------------------------------|

--- a/docs/releases/2020fs2r1.md
+++ b/docs/releases/2020fs2r1.md
@@ -1,6 +1,6 @@
 **Release**
 
-These are the user stories that were included in 2020s2r1:
+These are the user stories that were included in 2020fs2r1:
 
 | **Issue ID**   |**Developed by**                                                            |
 | -------------- |---------------------------------------------------------------------------|
@@ -49,9 +49,7 @@ After this release the features that were implemented were:
 * The guardian could change the look of a completed activity for the citizen
 * The guardian could lock the timer for the citizens
 * The activities has pictogram text shown
-* If an activity has a timer, an indicator is shown 
+* If an activity has a timer, an indicator is shown
 * Buttons to mark and unmark all activities for one day
 * The chosen setting shown in the setting page
 * Error popup when pictogram upload failed
-
-

--- a/docs/releases/2020fs3r1.md
+++ b/docs/releases/2020fs3r1.md
@@ -1,6 +1,6 @@
 **Release**
 
-These are the user stories that were included in 2020s3r1:
+These are the user stories that were included in 2020fs3r1:
 
 | **Issue ID**   |**Developed by**                                                            |
 | -------------- |---------------------------------------------------------------------------|

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -6,10 +6,9 @@ The following pages in this section describes the overall changes made for each 
 | -------- | -------------|
 | [2018S3R2](2018s3r2.md)    | Tuesday 08-05-2018 |
 | [2018S4R1](2018s4r1.md)    | Thursday 17-05-2018 |
-| [2019s1r1](2019s1r1.md)    |        N/A       |    
+| [2019s1r1](2019s1r1.md)    |        N/A       |
 | [2019S2R1](2019s2r1.md)    | Friday 05-04-2019|
 | [2019S3R1](2019s3r1.md)    | Friday 26-04-2019|
-| [2020S1R1](2020s1r1.md)    | Friday 03-04-2020|
-| [2020S2R1](2020s2r1.md)    | Friday 01-05-2020|
-| [2020S3R1](2020s3r1.md)    | Tuesday 19-05-2020|
-
+| [2020fS1R1](2020fs1r1.md)    | Friday 03-04-2020|
+| [2020fS2R1](2020fs2r1.md)    | Friday 01-05-2020|
+| [2020fS3R1](2020fs3r1.md)    | Tuesday 19-05-2020|


### PR DESCRIPTION
Changed file names for the releases in the first semester by adding an "f" after the year in order to support adding releases in the second semester. 

New releases this semester will then need to be named "2020e..."