### PR TITLE
Feature/139: The textfont size for the app, is described wrongly in the designguide

### DIFF
--- a/docs/development/design_guide/typography.md
+++ b/docs/development/design_guide/typography.md
@@ -15,7 +15,10 @@ especially in relation to the letter a.
 
 ## Font size
 
-The font size should follow the sizes in file FontSizes(Placeholder).
+The font size should follow the declared sizes in the file font_sizes. 
+In the file the font sizes for pictograms (150), timers (50) and the buttons for the activity screen (23) are declared. 
+Besides these there are also 3 general font sizes for the rest of the application, these being declared as small (20), 
+medium (24) and large (30). These are used for general text in the app and can be used as the developer sees fit.
 
 ## Bold, italic and underlined text
 


### PR DESCRIPTION
It is now described correctly in the design guide on the wiki.

Closes #139 